### PR TITLE
fix logger repeat create mkdir

### DIFF
--- a/proxy/logger.js
+++ b/proxy/logger.js
@@ -12,7 +12,10 @@ if (config.env !== 'production') {
 } else {
   customLogDir = path.join(os.homedir(), 'logs/xtransit-server');
 }
-fs.mkdirSync(customLogDir, { recursive: true });
+
+if (!fs.existsSync(customLogDir)) {
+  fs.mkdirSync(customLogDir, { recursive: true });
+}
 
 module.exports = Logger({
   dir: customLogDir,


### PR DESCRIPTION
解决重启服务后，日志文件夹重复创建导致的报错。
![image](https://user-images.githubusercontent.com/10388282/85093854-ea214280-b21f-11ea-8bd5-b775756ae2f4.png)
