### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 ENV NODE_ENV prod
 
-RUN npm config set registry https://registry.npm.taobao.org && npm install --prod
+RUN npm config set registry https://registry.npmmirror.com && npm install --prod
 
 EXPOSE 9090
 


### PR DESCRIPTION
老的 http://npm.taobao.org 和 http://registry.npm.taobao.org 域名将于 2022 年 05 月 31 日零时起停止服务