### PR TITLE
optimize: check transit agent is alive

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,11 @@ class XtransitServerBoot {
         handler
           .close(ws)
           .catch(err => logger.error(`ws handle close error: ${err}.`)));
+
+      // handle error event
+      ws.on('error', err => {
+        logger.error(`ws handle receive error: ${err}.`);
+      });
     });
 
     wss.on('error', err => logger.error(`websocket server error: ${err}.`));

--- a/app/controller/manager.js
+++ b/app/controller/manager.js
@@ -18,9 +18,17 @@ class ManagerController extends Controller {
     }
 
     const data = {};
-    for (let index = 0; index < clients.length; index++) {
-      const response = await ipc.request(clients[index], 'manager.checkClientAlive');
-      data[index] = response.ok;
+    const response = await ipc.broadcast(clients, 'manager.checkClientAlive');
+    for (const list of response) {
+      for (let index = 0; index < list.length; index++) {
+        // status checked
+        if (data[index]) {
+          continue;
+        }
+
+        // set exist status
+        data[index] = list[index].ok;
+      }
     }
 
     ctx.body = { ok: true, data };

--- a/app/service/ipc.js
+++ b/app/service/ipc.js
@@ -68,7 +68,7 @@ class IpcService extends Service {
   }
 
   async request(options, action, data = {}) {
-    const { ctx: { logger, app: { messenger, config: { channelMessageToApp, httpTimeout } } } } = this;
+    const { ctx: { app: { messenger, config: { channelMessageToApp, httpTimeout } } } } = this;
     const { appId, agentId, clientId } = options;
     const identity = this.composeClientIdentity(appId, agentId, clientId);
     const traceId = uuidv4();

--- a/app/service/ipc.js
+++ b/app/service/ipc.js
@@ -10,24 +10,40 @@ class IpcService extends Service {
       service: { websocket },
     } } = this;
     messenger.on(channelMessageToApp, async params => {
-      const { traceId, identity, action, data } = params;
-      if (!websocket.getClient(identity)) {
-        return messenger.sendToApp(traceId, {
-          ok: false,
-          code: errorCode.noClient,
-          message: `${websocket.getClientInfo(identity)} not connected`,
-        });
+      const { traceId, clients, identity, action, data } = params;
+      const responseList = [];
+      const broadcast = Array.isArray(clients);
+
+      const identities = broadcast
+        ? clients.map(({ appId, agentId, clientId }) => this.composeClientIdentity(appId, agentId, clientId))
+        : [identity];
+
+      for (const identity of identities) {
+        if (!websocket.getClient(identity)) {
+          responseList.push({
+            ok: false,
+            code: errorCode.noClient,
+            message: broadcast ? undefined : `${websocket.getClientInfo(identity)} not connected`,
+          });
+          continue;
+        }
+
+        const { service: { actions } } = app.createAnonymousContext();
+        try {
+          const list = action.split('.');
+          const property = list.pop();
+          const instance = list.reduce((map, key) => map[key], actions);
+          const result = await instance[property](identity, data);
+          responseList.push({ ok: true, data: result });
+        } catch (err) {
+          responseList.push({ ok: false, message: err.stack });
+        }
       }
 
-      const { service: { actions } } = app.createAnonymousContext();
-      try {
-        const list = action.split('.');
-        const property = list.pop();
-        const instance = list.reduce((map, key) => map[key], actions);
-        const result = await instance[property](identity, data);
-        messenger.sendToApp(traceId, { ok: true, data: result });
-      } catch (err) {
-        messenger.sendToApp(traceId, { ok: false, message: err.stack });
+      if (broadcast) {
+        messenger.sendToApp(traceId, responseList);
+      } else {
+        messenger.sendToApp(traceId, responseList[0]);
       }
     });
   }
@@ -47,10 +63,11 @@ class IpcService extends Service {
     }), expired));
   }
 
-  waitForResponse(traceId) {
+  waitForResponse(traceId, broadcast = false) {
     const { ctx: { app: { messenger, config: { errorCode }, options: { workers } } } } = this;
 
     return new Promise(resolve => {
+      const responseList = [];
       let count = 0;
 
       const done = response => {
@@ -59,6 +76,14 @@ class IpcService extends Service {
       };
 
       messenger.on(traceId, response => {
+        if (broadcast) {
+          responseList.push(response);
+          if (++count === workers) {
+            done(responseList);
+          }
+          return;
+        }
+
         if (response.code === errorCode.noClient && ++count !== workers) {
           return;
         }
@@ -67,19 +92,31 @@ class IpcService extends Service {
     });
   }
 
-  async request(options, action, data = {}) {
+  async request(client, action, data = {}) {
     const { ctx: { app: { messenger, config: { channelMessageToApp, httpTimeout } } } } = this;
-    const { appId, agentId, clientId } = options;
+    const { appId, agentId, clientId } = client;
     const identity = this.composeClientIdentity(appId, agentId, clientId);
     const traceId = uuidv4();
-    // logger.info(`[ipc.request] [${traceId}] <${JSON.stringify(options)}> execute ${action} request: ${JSON.stringify({ action, data })}`);
+    // logger.info(`[ipc.request] [${traceId}] <${JSON.stringify(client)}> execute ${action} request: ${JSON.stringify({ action, data })}`);
     messenger.sendToApp(channelMessageToApp, { traceId, identity, action, data });
 
     const tasks = [];
     tasks.push(this.timeout(data.expiredTime || httpTimeout, action));
     tasks.push(this.waitForResponse(traceId));
     const response = await Promise.race(tasks);
-    // logger.info(`[ipc.request] [${traceId}] <${JSON.stringify(options)}> execute ${action} response: ${JSON.stringify(response)}`);
+    // logger.info(`[ipc.request] [${traceId}] <${JSON.stringify(client)}> execute ${action} response: ${JSON.stringify(response)}`);
+    return response;
+  }
+
+  async broadcast(clients, action, data = {}) {
+    const { ctx: { app: { messenger, config: { channelMessageToApp, httpTimeout } } } } = this;
+    const traceId = uuidv4();
+    messenger.sendToApp(channelMessageToApp, { traceId, clients, action, data });
+
+    const tasks = [];
+    tasks.push(this.timeout(data.expiredTime || httpTimeout, action));
+    tasks.push(this.waitForResponse(traceId, true));
+    const response = await Promise.race(tasks);
     return response;
   }
 }

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -33,7 +33,7 @@ module.exports = appInfo => {
   // user config
   const userConfig = {};
 
-  userConfig.xtransitManager = '';
+  userConfig.xtransitManager = 'http://127.0.0.1:8543';
 
   return {
     ...config,


### PR DESCRIPTION
## 背景

当前实现的无状态 ws worker 存在一个问题，每次转发消息回通过 `clientId`, `agentId` 以及 `appId` 的组合计算标识符，判断当前需要查询的 xtransit client 是否在当前的 ws worker 连接。

当存在大量的 xtransit client （几千以上的规模）时，由于 IPC 的效率比较低，会造成性能骤降，导致实例概览查询很慢。

## 优化

这里提供一种广播 ipc 的方式，一次 IPC 转发所有需要查询的客户端连接信息，冗余的进程内操作是很快的，可以有效减少大量客户端连接场景下 IPC 数量，提升整体的查询性能。