### PR TITLE
fix: set default wsValidTime to 75s

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -11,7 +11,7 @@ module.exports = appInfo => {
 
   config.httpTimeout = 15000;
 
-  config.wsValidTime = 5000;
+  config.wsValidTime = 75 * 1000;
 
   config.channelMessageToApp = 'XPROFILER::CHANNEL_MESSAGE_TO_APP';
 
@@ -37,7 +37,7 @@ module.exports = appInfo => {
 
   userConfig.xtransitManager = 'http://127.0.0.1:8543';
 
-  userConfig.checkValid = false;
+  userConfig.checkValid = true;
 
   return {
     ...config,


### PR DESCRIPTION
ws connection 建立后，为了防止频繁重连和简化 client 重连逻辑，heartbeat 是按照原定 timer 进行上报的，默认 5s 的检查过短，会导致重连策略大概率被 server 断开导致连不上。

这里的 `wsValidTime` 不能太短，默认需要超过设定的心跳重连间隔：60s，同时为了防止服务间有些微时间差，增加 15s 余量，因此默认 `wsValidTime` 需要配置为 75s。